### PR TITLE
[ISSUE #3762]Redundant import and return statements.

### DIFF
--- a/cmd/controller/workflow.go
+++ b/cmd/controller/workflow.go
@@ -120,7 +120,6 @@ func (c *WorkflowController) QueryDetail(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusOK, &QueryWorkflowResponse{Workflow: *res})
-	return
 }
 
 // Delete delete a workflow


### PR DESCRIPTION
Fixes #3762

Removed the redundant `return` at line 123