### PR TITLE
[ISSUE #3762]Redundant import and return statements.

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/constants"
 	"github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/dal"
 	"github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/queue"
-	_ "github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/queue"
 	"github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/schedule"
 	"github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/util"
 	"google.golang.org/grpc"


### PR DESCRIPTION
Fixes #3762

Removed the redundant `"github.com/apache/incubator-eventmesh/eventmesh-workflow-go/internal/queue"` at line 34